### PR TITLE
Added OwnerHist Command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -48,6 +48,8 @@ func userCommand(s *discordgo.Session, m *discordgo.MessageCreate, command strin
 		listAvailableRolesCommand(s, m)
 	case "myroles":
 		listMyRolesCommand(s, m)
+	case "ownerhist":
+		ownerHist(s, m)
 	default:
 		dmCommand(s, m, command)
 	}
@@ -87,6 +89,9 @@ func adminCommand(s *discordgo.Session, m *discordgo.MessageCreate, command stri
 		logCommand(s, m)
 	case "unmute":
 		unmuteCommand(s, m)
+		logCommand(s, m)
+	case "ownerhist":
+		ownerHist(s, m)
 		logCommand(s, m)
 	default:
 		userCommand(s, m, command)
@@ -447,4 +452,10 @@ func makeBigLettersCommand(s *discordgo.Session, m *discordgo.MessageCreate) {
 		message += " "
 	}
 	s.ChannelMessageSend(m.ChannelID, message)
+}
+
+func ownerHist(s *discordgo.Session, m *discordgo.MessageCreate) {
+	//simple and possibly unnecessary but whatever
+	s.ChannelMessageSend(m.ChannelID, `December 2018 - June 2020: Patchkat
+					   June 2020 - Present: Astroturtle`)
 }

--- a/commands.go
+++ b/commands.go
@@ -453,6 +453,6 @@ func makeBigLettersCommand(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 func ownerHist(s *discordgo.Session, m *discordgo.MessageCreate) {
 	//simple and possibly unnecessary but whatever
-	s.ChannelMessageSend(m.ChannelID, `December 2018 - June 2020: Patchkat
-					   June 2020 - Present: Astroturtle`)
+	s.ChannelMessageSend(m.ChannelID, "December 2018 (Server Creation) - June 2020: Patchkat\n" +
+			     "June 2020 - Present: Astroturtle")
 }

--- a/commands.go
+++ b/commands.go
@@ -453,6 +453,6 @@ func makeBigLettersCommand(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 func ownerHist(s *discordgo.Session, m *discordgo.MessageCreate) {
 	//simple and possibly unnecessary but whatever
-	s.ChannelMessageSend(m.ChannelID, "December 2018 (Server Creation) - June 2020: Patchkat\n" +
-			     "June 2020 - Present: Astroturtle")
+	ownerHistEmb := getOwnerHistEmbed(s)
+	s.ChannelMessageSendEmbed(m.ChannelID, ownerHistEmb)
 }

--- a/commands.go
+++ b/commands.go
@@ -90,9 +90,6 @@ func adminCommand(s *discordgo.Session, m *discordgo.MessageCreate, command stri
 	case "unmute":
 		unmuteCommand(s, m)
 		logCommand(s, m)
-	case "ownerhist":
-		ownerHist(s, m)
-		logCommand(s, m)
 	default:
 		userCommand(s, m, command)
 	}

--- a/embeds.go
+++ b/embeds.go
@@ -60,7 +60,8 @@ func getServerHelpEmbed() *discordgo.MessageEmbed {
 			"`addrole` - give yourself a role\n" +
 			"`delrole` - remove a role from yourself\n" +
 			"`roles` - list roles available to you\n" +
-			"`myroles` - list your roles",
+			"`myroles` - list your roles\n" +
+			"`ownerhist` - see owner history of this server",
 		Inline: false,
 	})
 	return embed

--- a/embeds.go
+++ b/embeds.go
@@ -177,6 +177,26 @@ func getServerEmbed(s *discordgo.Session, g *discordgo.Guild, u *discordgo.User)
 	return embed
 }
 
+func getOwnerHistEmbed(s *discordgo.Session, g *discordgo.Guild) *discordgo.MessageEmbed {
+
+	embed := getBaseEmbed()
+	embed.Title = "Owner History"
+	embed.Fields = []*discordgo.MessageEmbedField{
+		&discordgo.MessageEmbedField{
+			Name: "Patchkat",
+			Value: "December 2018 (Server Creation) - June 2020",
+			Inline: false,
+		},
+		&discordgo.MessageEmbedField{
+			Name: "Astroturtle",
+			Value: "June 2020 - Present",
+			Inline: false,
+		},
+	}
+	return embed
+	
+}
+
 func getLastFMTrackEmbed(mostRecentTrack lastFMSong) *discordgo.MessageEmbed {
 	embed := getBaseEmbed()
 	embed.Title = mostRecentTrack.Name

--- a/embeds.go
+++ b/embeds.go
@@ -177,7 +177,7 @@ func getServerEmbed(s *discordgo.Session, g *discordgo.Guild, u *discordgo.User)
 	return embed
 }
 
-func getOwnerHistEmbed(s *discordgo.Session, g *discordgo.Guild) *discordgo.MessageEmbed {
+func getOwnerHistEmbed(s *discordgo.Session) *discordgo.MessageEmbed {
 
 	embed := getBaseEmbed()
 	embed.Title = "Owner History"


### PR DESCRIPTION
Used to view owner history of the CA Discord, not built to work with a custom configuration on a different server but that will be next on the list assuming this is pulled into the main repo and this is actually used. 

At the moment, I have a couple ideas for how to make a custom thing work but it would most likely require a new .txt or json file in the same dir with each owner's username (not the #XXXX id, other part) and how long. 

To fully automate this process would likely be a bit difficult and require automatic checking on the bot's side but can be done if ownerhist will actually be used.

If there are any issues, please lmk